### PR TITLE
Add startup cpu boost annotation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.62.3
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -2,20 +2,7 @@ Terraform Module: Google Cloud Run
 ==================================
 
 A Terraform module for the [Google Cloud Platform](https://cloud.google.com) that simplifies the creation & configuration
-of a Cloud Run (Fully Managed) service.
-
-# Table of contents
-
-* [Introduction](#introduction)
-* [Requirements](#requirements)
-* [Usage](#usage)
-* [Secrets & Volumes](#secrets--volumes)
-* [Inputs](#inputs)
-  * [Required](#required-inputs)
-  * [Optional](#optional-inputs)
-* [Outputs](#outputs)
-* [Changelog](#changelog)
-* [Roadmap](#roadmap)
+of a Cloud Run (Fully Managed) service. This has been forked from [`garbetjie/terraform-google-cloud-run`](https://github.com/garbetjie/terraform-google-cloud-run)
 
 # Introduction
 
@@ -26,51 +13,6 @@ It attempts to be as complete as possible, and expose as much functionality as i
 As a result, some functionality might only be provided as part of BETA releases. Google's SLA support for this level of
 functionality is often not as solid as with Generally-Available releases. If you require absolute stability, this module
 might not be the best for you.
-
-# Requirements
-
-* Terraform 0.14 or higher.
-* `google` provider 3.67.0 or higher.
-* `google-beta` provider 3.67.0 or higher.
-
-# Usage
-
-```hcl-terraform
-module my_cloud_run_service {
-  source = "garbetjie/cloud-run/google"
-  version = "~> 2"
-  
-  # Required parameters
-  name = "my-cloud-run-service"
-  image = "us-docker.pkg.dev/cloudrun/container/hello"
-  location = "europe-west4"
-  
-  # Optional parameters
-  allow_public_access = true
-  args = []
-  cloudsql_connections = []
-  concurrency = 80
-  cpu_throttling = true
-  execution_environment = "gen2"
-  cpus = 1
-  entrypoint = []
-  env = [{ key = "ENV_VAR_KEY", value = "ENV_VAR_VALUE" }]
-  execution_environment = "gen1"
-  ingress = "all"
-  labels = {}
-  map_domains = []
-  max_instances = 1000
-  memory = 256
-  min_instances = 0
-  port = 8080
-  project = null
-  revision = null
-  service_account_email = null
-  timeout = 60
-  volumes = [{ path = "/mnt", secret = "my-secret", filenames = { "latest" = "latest" }}]
-  vpc_access = { connector = null, egress = null }
-}
-```
 
 # Secrets & Volumes
 
@@ -86,108 +28,104 @@ through the `volumes` and `env` input variables respectively.
 
 Refer to https://cloud.google.com/run/docs/configuring/secrets for further reading on secrets in Cloud Run.
 
-# Inputs
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
 
-## Required inputs
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.67.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.67.0 |
 
-| Name     | Description                                                                          | Type   |
-|----------|--------------------------------------------------------------------------------------|--------|
-| name     | Name of the service.                                                                 | string |
-| image    | Docker image name. Must be hosted in Google Container Registry or Artifact Registry. | string |
-| location | Location of the service.                                                             | string |
+## Providers
 
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.67.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.67.0 |
 
-## Optional inputs
+## Modules
 
-| Name                  | Description                                                                                                                                                                        | Type                                                                                                           | Default                               | Required |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|---------------------------------------|----------|
-| allow_public_access   | Allow unauthenticated access to the service.                                                                                                                                       | bool                                                                                                           | `true`                                | No       |
-| args                  | Arguments to pass to the entrypoint.                                                                                                                                               | list(string)                                                                                                   | `[]`                                  | No       |
-| cloudsql_connections  | Cloud SQL connections to attach to container instances.                                                                                                                            | set(string)                                                                                                    | `[]`                                  | No       |
-| concurrency           | Maximum allowed concurrent requests per container for this revision.                                                                                                               | number                                                                                                         | `null`                                | No       |
-| cpu_throttling        | Configure CPU throttling outside of request processing.                                                                                                                            | bool                                                                                                           | `true`                                | No       |
-| cpus                  | Number of CPUs to allocate per container.                                                                                                                                          | number                                                                                                         | `1`                                   | No       |
-| entrypoint            | Entrypoint command. Defaults to the image's ENTRYPOINT if not provided.                                                                                                            | list(string)                                                                                                   | `[]`                                  | No       |
-| env                   | Environment variables to inject into container instances. Exactly one of `value` or `secret` must be specified.                                                                    | set(object({ key = string, value = optional(string), secret = optional(string), version = optional(string) })) | `[]`                                  | No       |
-| env.*.key             | Name of the environment variable.                                                                                                                                                  | string                                                                                                         |                                       | Yes      |
-| env.*.value           | Raw string value of the environment variable.                                                                                                                                      | optional(string)                                                                                               | `null`                                | No       |
-| env.*.secret          | Secret to populate the environment variable from. Secrets in other projects should use the `projects/{{project}}/secrets/{{secret}}` format.                                       | optional(string)                                                                                               | `null`                                | No       |
-| env.*.version         | Version to use when populating with a secret. Defaults to the latest version.                                                                                                      | string                                                                                                         | `"latest"`                            | No       |
-| execution_environment | Execution environment to run under. Allowed values: [`"gen1"`, `"gen2"`]                                                                                                           | string                                                                                                         | `"gen1"`                              | No       |
-| http2                 | Enable use of HTTP/2 end-to-end.                                                                                                                                                   | bool                                                                                                           | `false`                               | No       |
-| ingress               | Ingress settings for the service. Allowed values: [`"all"`, `"internal"`, `"internal-and-cloud-load-balancing"`]                                                                   | string                                                                                                         | `all`                                 | No       |
-| labels                | [Labels](https://cloud.google.com/run/docs/configuring/labels) to apply to the service.                                                                                            | map(string)                                                                                                    | `{}`                                  | No       |
-| map_domains           | Domain names to map to the service.                                                                                                                                                | set(string)                                                                                                    | `[]`                                  | No       |
-| max_instances         | Maximum number of container instances allowed to start.                                                                                                                            | number                                                                                                         | `1000`                                | No       |
-| memory                | Memory (in Mi) to allocate to containers. If `execution_environment` is `"gen2"`, this needs to be >= 512.                                                                         | number                                                                                                         | `256`                                 | No       |
-| min_instances         | Minimum number of container instances to keep running.                                                                                                                             | number                                                                                                         | `0`                                   | No       |
-| port                  | Port on which the container is listening for incoming HTTP requests.                                                                                                               | number                                                                                                         | `8080`                                | No       |
-| project               | Google Cloud project in which to create resources.                                                                                                                                 | string                                                                                                         | `null`                                | No       |
-| revision              | Revision name to use. When `null`, revision names are automatically generated.                                                                                                     | string                                                                                                         | `null`                                | No       |
-| service_account_email | IAM service account email to assign to container instances.                                                                                                                        | string                                                                                                         | `null`                                | No       |
-| timeout               | Maximum duration (in seconds) allowed for responding to requests.                                                                                                                  | number                                                                                                         | `60`                                  | No       |
-| volumes               | Volumes to be mounted & populated from secrets.                                                                                                                                    | set(object({ path = string, secret = string, versions = optional(map(string)) }))                              | `[]`                                  | No       |
-| volumes.*.path        | Path into which the secret will be mounted. The same path cannot be specified for multiple volumes.                                                                                | string                                                                                                         |                                       | Yes      |
-| volumes.*.secret      | The secret to mount into the service container. Secrets in other projects should use the `projects/{{project}}/secrets/{{secret}}` format.                                         | string                                                                                                         |                                       | Yes      |
-| volumes.*.versions    | A map of files and versions to be mounted into the path. Keys are file names to be created, and the value is the version of the secret to use (`"latest"` for the latest version). | map(string)                                                                                                    | `{ latest = "latest" }`               | No       |
-| vpc_access            | Control VPC access for the service.                                                                                                                                                | object({ connector = optional(string), egress = optional(string) })                                            | `{ connector = null, egress = null }` | No       |
-| vpc_access.connector  | Name of the VPC connector to use. Connectors in other projects should use the `projects/{{projects}}/locations/${var.location}/connectors/{{connector}}` format.                   | string                                                                                                         | `null`                                | No       |
-| vpc_access.egress     | Configure behaviour of egress traffic from this service. Can be one of `"all-traffic"` or `"private-ranges-only"`.                                                                 | string                                                                                                         | `"private-ranges-only"`               | No       |
+No modules.
 
-# Outputs
+## Resources
 
-In addition to the inputs documented above, the following values are available as outputs:
+| Name | Type |
+|------|------|
+| [google-beta_google_cloud_run_service.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloud_run_service) | resource |
+| [google_cloud_run_domain_mapping.domains](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_domain_mapping) | resource |
+| [google_cloud_run_service_iam_member.public_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
 
-| Name                         | Description                                                                                                | Type                                                                                                |
-|------------------------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-| latest_ready_revision_name   | Latest revision ready for use.                                                                             | string                                                                                              |
-| latest_created_revision_name | Last revision created.                                                                                     | string                                                                                              |
-| url                          | URL at which the service is available.                                                                     | string                                                                                              |
-| id                           | ID of the created service.                                                                                 | string                                                                                              |
-| dns                          | DNS records to populate for mapped domains. Keys are the domains that were specified in `var.map_domains`. | map(list(object({ name = optional(string), root = string, type = string, rrdatas = set(string) }))) |
+## Inputs
 
-# Changelog
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_public_access"></a> [allow\_public\_access](#input\_allow\_public\_access) | Allow unauthenticated access to the service. | `bool` | `true` | no |
+| <a name="input_args"></a> [args](#input\_args) | Arguments to pass to the entrypoint. | `list(string)` | `[]` | no |
+| <a name="input_cloudsql_connections"></a> [cloudsql\_connections](#input\_cloudsql\_connections) | Cloud SQL connections to attach to container instances. | `set(string)` | `[]` | no |
+| <a name="input_concurrency"></a> [concurrency](#input\_concurrency) | Maximum allowed concurrent requests per container for this revision. | `number` | `null` | no |
+| <a name="input_cpu_throttling"></a> [cpu\_throttling](#input\_cpu\_throttling) | Configure CPU throttling outside of request processing. | `bool` | `true` | no |
+| <a name="input_cpus"></a> [cpus](#input\_cpus) | Number of CPUs to allocate per container. | `number` | `1` | no |
+| <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | Entrypoint command. Defaults to the image's ENTRYPOINT if not provided. | `list(string)` | `[]` | no |
+| <a name="input_env"></a> [env](#input\_env) | Environment variables to inject into container instances. | <pre>set(<br>    object({<br>      key     = string,<br>      value   = optional(string),<br>      secret  = optional(string),<br>      version = optional(string),<br>    })<br>  )</pre> | `[]` | no |
+| <a name="input_execution_environment"></a> [execution\_environment](#input\_execution\_environment) | Execution environment to run container instances under. | `string` | `"gen1"` | no |
+| <a name="input_http2"></a> [http2](#input\_http2) | Enable use of HTTP/2 end-to-end. | `bool` | `false` | no |
+| <a name="input_image"></a> [image](#input\_image) | Docker image name. | `string` | n/a | yes |
+| <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress settings for the service. Allowed values: [`"all"`, `"internal"`, `"internal-and-cloud-load-balancing"`] | `string` | `"all"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the service. | `map(string)` | `{}` | no |
+| <a name="input_location"></a> [location](#input\_location) | Location of the service. | `string` | n/a | yes |
+| <a name="input_map_domains"></a> [map\_domains](#input\_map\_domains) | Domain names to map to the service. | `set(string)` | `[]` | no |
+| <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | Maximum number of container instances allowed to start. | `number` | `1000` | no |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory (in Mi) to allocate to containers. Minimum of 512Mi is required when `execution_environment` is `"gen2"`. | `number` | `256` | no |
+| <a name="input_min_instances"></a> [min\_instances](#input\_min\_instances) | Minimum number of container instances to keep running. | `number` | `0` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the service. | `string` | n/a | yes |
+| <a name="input_port"></a> [port](#input\_port) | Port on which the container is listening for incoming HTTP requests. | `number` | `8080` | no |
+| <a name="input_project"></a> [project](#input\_project) | Google Cloud project in which to create resources. | `string` | `null` | no |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision name to use. When `null`, revision names are automatically generated. | `string` | `null` | no |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | IAM service account email to assign to container instances. | `string` | `null` | no |
+| <a name="input_startup_cpu_boost"></a> [startup\_cpu\_boost](#input\_startup\_cpu\_boost) | Start containers faster by allocating more CPU during start-up time. | `bool` | `false` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Maximum duration (in seconds) allowed for responding to requests. | `number` | `60` | no |
+| <a name="input_volumes"></a> [volumes](#input\_volumes) | Volumes to be mounted & populated from secrets. | `set(object({ path = string, secret = string, versions = optional(map(string)) }))` | `[]` | no |
+| <a name="input_vpc_access"></a> [vpc\_access](#input\_vpc\_access) | Control VPC access for the service. | `object({ connector = optional(string), egress = optional(string) })` | <pre>{<br>  "connector": null,<br>  "egress": null<br>}</pre> | no |
+| <a name="input_vpc_access_egress"></a> [vpc\_access\_egress](#input\_vpc\_access\_egress) | Specify whether to divert all outbound traffic through the VPC, or private ranges only (Deprecated - use `var.vpc_access.egress` instead). | `string` | `"private-ranges-only"` | no |
+| <a name="input_vpc_connector_name"></a> [vpc\_connector\_name](#input\_vpc\_connector\_name) | VPC connector to apply to this service (Deprecated - use `var.vpc_access.connector` instead). | `string` | `null` | no |
 
-* **2.2.1**
-    * Add `run.googleapis.com/launch-stage` to ignored annotations, preventing unnecessary updates in place. 
+## Outputs
 
-* **2.2.0**
-    * Implement [execution environment](https://cloud.google.com/run/docs/configuring/execution-environments) configuration (thanks @dennislapchenko).
-
-* **2.1.1**
-    * Placed `run.googleapis.com/launch-stage` in the service's annotations, not the revision's. 
-
-* **2.1.0**
-    * Implement CPU throttling configuration (thanks @salimkayabasi).
-    * Implement HTTP/2 end-to-end support.
-
-* **2.0.0**
-    * Switch to using the `google-beta` provider for Cloud Run services.
-    * Bump minimum required versions: `terraform >= 0.14`, `google-beta >= 3.67.0`, `google >= 3.67.0`.
-    * Add support for secrets as environment variables & volumes.
-    * Add ability to configure the container's entrypoint and arguments.
-    * Add inputs as outputs.
-    
-* **1.4.0**
-    * Ignore additional annotations in order to prevent unnecessary diffs:
-      * `run.googleapis.com/sandbox`
-      * `serving.knative.dev/creator`
-      * `serving.knative.dev/lastModifier`
-    * Add outputs `location` and `id`.
-
-* **1.3.0**
-    * Add `ingress` input variable - to specify the level of network access restriction on the service.
-
-* **1.2.0**
-    * Add `labels` input variable - to apply custom [labels](https://cloud.google.com/run/docs/configuring/labels) to the Cloud Run service
-  
-* **1.1.0**
-    * Add `project` variable, to be able to specify the project in which to create the Cloud Run service.
-
-* **1.0.0**
-    * Release stable version.
-    * Add BETA launch-stage to service (fixes inability to use `min_instances`).
-
-# Roadmap
-
-Issues containing possible future enhancements can be found [here](https://github.com/garbetjie/terraform-google-cloud-run/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement).
+| Name | Description |
+|------|-------------|
+| <a name="output_allow_public_access"></a> [allow\_public\_access](#output\_allow\_public\_access) | Allow unauthenticated access to the service. |
+| <a name="output_args"></a> [args](#output\_args) | Arguments passed to the entrypoint. |
+| <a name="output_cloudsql_connections"></a> [cloudsql\_connections](#output\_cloudsql\_connections) | Cloud SQL connections attached to container instances. |
+| <a name="output_concurrency"></a> [concurrency](#output\_concurrency) | Maximum allowed concurrent requests per container for the created revision. |
+| <a name="output_cpu_throttling"></a> [cpu\_throttling](#output\_cpu\_throttling) | Configuration for CPU throttling outside of request processing. |
+| <a name="output_cpus"></a> [cpus](#output\_cpus) | Number of CPUs allocated per container. |
+| <a name="output_cpus_suffixed"></a> [cpus\_suffixed](#output\_cpus\_suffixed) | CPUs allocated per container, specified with the millicpu suffix (eg: "1000m" if `var.cpus` is 1). |
+| <a name="output_dns"></a> [dns](#output\_dns) | DNS records to populate for mapped domains. Keys are the domains that are mapped. |
+| <a name="output_entrypoint"></a> [entrypoint](#output\_entrypoint) | Entrypoint command used in the service. |
+| <a name="output_env"></a> [env](#output\_env) | Environment variables injected into container instances. |
+| <a name="output_execution_environment"></a> [execution\_environment](#output\_execution\_environment) | Execution environment container instances are running under. |
+| <a name="output_http2"></a> [http2](#output\_http2) | Status of HTTP/2 end-to-end handling. |
+| <a name="output_id"></a> [id](#output\_id) | ID of the created service. |
+| <a name="output_image"></a> [image](#output\_image) | Docker image name. |
+| <a name="output_ingress"></a> [ingress](#output\_ingress) | Ingress settings applied to the service. |
+| <a name="output_labels"></a> [labels](#output\_labels) | Labels applied to the service. |
+| <a name="output_latest_created_revision_name"></a> [latest\_created\_revision\_name](#output\_latest\_created\_revision\_name) | Last revision created. |
+| <a name="output_latest_ready_revision_name"></a> [latest\_ready\_revision\_name](#output\_latest\_ready\_revision\_name) | Latest revision ready for use. |
+| <a name="output_location"></a> [location](#output\_location) | Location of the service. |
+| <a name="output_map_domains"></a> [map\_domains](#output\_map\_domains) | Domain names mapped to the service. |
+| <a name="output_max_instances"></a> [max\_instances](#output\_max\_instances) | Maximum number of container instances allowed to start. |
+| <a name="output_memory"></a> [memory](#output\_memory) | Memory (in Mi) allocated to container instances. |
+| <a name="output_memory_suffixed"></a> [memory\_suffixed](#output\_memory\_suffixed) | Memory allocated to containers instances, with the relevant suffix (eg: "256Mi" if `var.memory` is 256). |
+| <a name="output_min_instances"></a> [min\_instances](#output\_min\_instances) | Minimum number of container instances to keep running. |
+| <a name="output_name"></a> [name](#output\_name) | Name of the service. |
+| <a name="output_port"></a> [port](#output\_port) | Port on which the container is listening for incoming HTTP requests. |
+| <a name="output_project"></a> [project](#output\_project) | Google Cloud project in which resources were created. |
+| <a name="output_revision"></a> [revision](#output\_revision) | Revision name that was created. |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | IAM service account email to assigned to container instances. |
+| <a name="output_timeout"></a> [timeout](#output\_timeout) | Maximum duration (in seconds) allowed for responding to requests. |
+| <a name="output_url"></a> [url](#output\_url) | URL at which the service is available. |
+| <a name="output_volumes"></a> [volumes](#output\_volumes) | Secrets mounted as volumes into the service. |
+| <a name="output_vpc_access"></a> [vpc\_access](#output\_vpc\_access) | VPC access configuration. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ resource "google_cloud_run_service" "default" {
           "autoscaling.knative.dev/maxScale"         = var.max_instances
           "autoscaling.knative.dev/minScale"         = var.min_instances
           "run.googleapis.com/execution-environment" = var.execution_environment
+          "run.googleapis.com/startup-cpu-boost"     = var.startup_cpu_boost
         },
         local.vpc_access.connector == null ? {} : {
           "run.googleapis.com/vpc-access-connector" = local.vpc_access.connector

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,12 @@ variable "service_account_email" {
   description = "IAM service account email to assign to container instances."
 }
 
+variable "startup_cpu_boost" {
+  type        = bool
+  default     = false
+  description = "Start containers faster by allocating more CPU during start-up time."
+}
+
 variable "timeout" {
   type        = number
   default     = 60


### PR DESCRIPTION
Add startup cpu boost annotation. This allows us to start containers faster by allocating more CPU during start-up time.