### PR TITLE
feat: prevent duplicate environment variables [PE-969]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "google_cloud_run_service" "default" {
 
         # Populate straight environment variables.
         dynamic "env" {
-          for_each = [for e in local.env : e if e.value != null]
+          for_each = { for i in [for e in local.env : e if e.value != null] : i.key => i }
 
           content {
             name  = env.value.key
@@ -68,7 +68,7 @@ resource "google_cloud_run_service" "default" {
 
         # Populate environment variables from secrets.
         dynamic "env" {
-          for_each = [for e in local.env : e if e.secret.name != null]
+          for_each = { for i in [for e in local.env : e if e.secret.name != null] : i.key => i }
 
           content {
             name = env.value.key


### PR DESCRIPTION
Using a Terraform `for` expression to prevent keys with the same value.


> If the result type is an object (using `{` and `}` delimiters) then normally the given key expression must be unique across all elements in the result, or Terraform will return an error.
<sub>https://developer.hashicorp.com/terraform/language/expressions/for#grouping-results</sub>


This error will show that there's a duplicate object and will show which key is duplicated. Example below:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Duplicate object key
│ 
│   on .terraform/modules/cloud_run/main.tf line 61, in resource "google_cloud_run_service" "default":
│   61:           for_each = { for i in [for e in local.env : e if e.value != null] : i.key => i }
│     ├────────────────
│     │ i.key is "EXTENDED_WEBHOOKS_ENABLED"
│ 
│ Two different items produced the key "EXTENDED_WEBHOOKS_ENABLED" in this
│ 'for' expression. If duplicates are expected, use the ellipsis (...) after
│ the value expression to enable grouping by key.
╵
```